### PR TITLE
sa-update fails due to util_rb_3tld having no entry per line for sa versions < 3.4.1

### DIFF
--- a/rules/20_aux_tlds.cf
+++ b/rules/20_aux_tlds.cf
@@ -914,7 +914,27 @@ util_rb_3tld ipfs.w3s.link
 util_rb_3tld lkd.co.im
 util_rb_3tld ltd.co.im
 # Mailchimp datacenter regions (us1-us21) used in list-manage.com list management URLs
-util_rb_3tld us1.list-manage.com us2.list-manage.com us3.list-manage.com us4.list-manage.com us5.list-manage.com us6.list-manage.com us7.list-manage.com us8.list-manage.com us9.list-manage.com us10.list-manage.com us11.list-manage.com us12.list-manage.com us13.list-manage.com us14.list-manage.com us15.list-manage.com us16.list-manage.com us17.list-manage.com us18.list-manage.com us19.list-manage.com us20.list-manage.com us21.list-manage.com
+util_rb_3tld us1.list-manage.com
+util_rb_3tld us2.list-manage.com
+util_rb_3tld us3.list-manage.com
+util_rb_3tld us4.list-manage.com
+util_rb_3tld us5.list-manage.com
+util_rb_3tld us6.list-manage.com
+util_rb_3tld us7.list-manage.com
+util_rb_3tld us8.list-manage.com
+util_rb_3tld us9.list-manage.com
+util_rb_3tld us10.list-manage.com
+util_rb_3tld us11.list-manage.com
+util_rb_3tld us12.list-manage.com
+util_rb_3tld us13.list-manage.com
+util_rb_3tld us14.list-manage.com
+util_rb_3tld us15.list-manage.com
+util_rb_3tld us16.list-manage.com
+util_rb_3tld us17.list-manage.com
+util_rb_3tld us18.list-manage.com
+util_rb_3tld us19.list-manage.com
+util_rb_3tld us20.list-manage.com
+util_rb_3tld us21.list-manage.com
 util_rb_3tld mobile.web.tr
 util_rb_3tld my.site.com
 util_rb_3tld no-ip.co.uk


### PR DESCRIPTION
sa-update fails due to util_rb_3tld needing one entry per line in 20_aux_tlds.cf on sa versions < 3.4.1

Especially this comment in the code is somewhat concerning

` 871 # 3rd level TLD list (SA 3.3+)
 872 #
 873 # There was a bug before 3.4.1(?), only one 3TLD per line works!
 874 #
 875 
 876 if (version >= 3.003000)
`
log entries:

`config: SpamAssassin failed to parse line, "us1.list-manage.com us2.list-manage.com us3.list-manage.com us4.list-manage.com us5.list-manage.com us6.list-manage.com us7.list-manage.com us8.list-manage.com us9.list-manage.com us10.list-manage.com us11.list-manage.com us12.list-manage.com us13.list-manage.com us14.list-manage.com us15.list-manage.com us16.list-manage.com us17.list-manage.com us18.list-manage.com us19.list-manage.com us20.list-manage.com us21.list-manage.com" is not valid for "util_rb_3tld", skipping: util_rb_3tld us1.list-manage.com us2.list-manage.com us3.list-manage.com us4.list-manage.com us5.list-manage.com us6.list-manage.com us7.list-manage.com us8.list-manage.com us9.list-manage.com us10.list-manage.com us11.list-manage.com us12.list-manage.com us13.list-manage.com us14.list-manage.com us15.list-manage.com us16.list-manage.com us17.list-manage.com us18.list-manage.com us19.list-manage.com us20.list-manage.com us21.list-manage.com`
