### PR TITLE
make the rule compatible with SpamAssassin 3.x

### DIFF
--- a/rulesrc/sandbox/fkento/20_calendar.cf
+++ b/rulesrc/sandbox/fkento/20_calendar.cf
@@ -1,5 +1,5 @@
 if can(Mail::SpamAssassin::Conf::feature_handlers)
-ifhandler Mail::SpamAssassin::Handler::ICS
+ifplugin Mail::SpamAssassin::Handler::ICS
 
 body          FKO_CAL_RAND_START  eval:check_ics_random_start_time()
 score         FKO_CAL_RAND_START  2.0  # limit


### PR DESCRIPTION
SpamAssassin 3.x breaks on "ifhandler", we should use "ifplugin" to make the parser happy